### PR TITLE
db_init.py to import schema into a NEW db

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ seaborn
 scikit-learn
 pymysql
 psycopg2-binary
-
+python_dotenv

--- a/scripts/db_init.py
+++ b/scripts/db_init.py
@@ -1,42 +1,47 @@
-
 import sqlite3
+import os
 
-# Connect to sqlite db 
-conn = sqlite3.connect('new_development.db')
-cursor = conn.cursor()
+def get_schema(db_path, tables):
+    """Get the schema for the specified tables from the SQLite database."""
+    schema = []
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.cursor()
+        placeholders = ','.join('?' for table in tables)
+        cursor.execute(f"SELECT name, sql FROM sqlite_master WHERE type='table' AND name IN ({placeholders});", tables)
+        schema = cursor.fetchall()
+    return schema
 
-# 'users' table
-cursor.execute('''
-CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    _name TEXT,
-    _uid TEXT,
-    _password TEXT,
-    _role TEXT,
-    _pfp TEXT,
-    kasm_server_needed BOOLEAN,
-    status INTEGER
-)
-''')
+def print_schema(schema):
+    """Print the schema."""
+    for table_name, table_sql in schema:
+        print(f"Table name: {table_name}")
+        print(f"Schema: {table_sql}\n")
 
-#  'sections' table
-cursor.execute('''
-CREATE TABLE IF NOT EXISTS sections (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    _name TEXT,
-    _abbreviation TEXT
-)
-''')
+def build_new_db(new_db_path, schema):
+    """Build a new SQLite database using the provided schema."""
+    with sqlite3.connect(new_db_path) as conn:
+        cursor = conn.cursor()
+        for table_name, table_sql in schema:
+            cursor.execute(table_sql)
+        conn.commit()
 
-# 'user_sections' table
-cursor.execute('''
-CREATE TABLE IF NOT EXISTS user_sections (
-    user_id INTEGER,
-    section_id INTEGER,
-    FOREIGN KEY(user_id) REFERENCES users(id),
-    FOREIGN KEY(section_id) REFERENCES sections(id)
-)
-''')
+# Paths to the old and new databases
+old_db_path = 'instance/volumes/sqlite.db'
+new_db_path = 'instance/volumes/sqlite_v2.db'
+    
+    # List of tables to transfer
+tables_to_transfer = ['users', 'user_sections', 'sections']
+    
+    # Create the directory if it doesn't exist
+os.makedirs(os.path.dirname(new_db_path), exist_ok=True)
+    
+    # Get the schema from the old database for the specified tables
+schema = get_schema(old_db_path, tables_to_transfer)
+    
+    # Print the schema
+print_schema(schema)
+    
+    # Build the new database with the extracted schema
+build_new_db(new_db_path, schema)
 
-conn.commit()
-conn.close()
+print(f"New database created successfully at {new_db_path}.")


### PR DESCRIPTION
<img width="947" alt="image" src="https://github.com/user-attachments/assets/8586f024-46ea-4c01-875d-6ebdeff9110d">
- we want to create sqlite_v2 (which will eventually have data changes from API ) 
- for this we need to extract the schema from sqlite.db (already have code from this in db_schema), I wanted to leave this untouched so I worked on fixing db_init.py 

NOTE : “SQLAlchemy 1.4 and later, the execute method was deprecated and  removed from the Engine object. So I am using the Connection object to execute raw SQL queries.” 


1) Ran new db_init.py 

2) Observe new table , with specified tables. This script is easy because we can customize which tables to migrate, and which db to migrate from. Eventually I may have a global variable called "sql version" , so the file which connects to rds can utilize the correct version of sql.db (sql_v2.db versus sql_v3.db versus sql_v4.db , etc.)

<img width="947" alt="image" src="https://github.com/user-attachments/assets/1fc700d2-76ca-484e-b476-65df66e7a831">
<img width="712" alt="image" src="https://github.com/user-attachments/assets/e0d7de45-199b-4e9c-a26d-4f80cdd46332">
<img width="712" alt="image" src="https://github.com/user-attachments/assets/36034438-8e25-48ba-a43c-98e6587ce6b1">
<img width="712" alt="image" src="https://github.com/user-attachments/assets/d6a02e5a-4b1e-4c5a-80f9-ea3a40a1f4cf">
